### PR TITLE
Event name refactor

### DIFF
--- a/src/main/java/org/teleight/teleightbots/api/methods/SendMessage.java
+++ b/src/main/java/org/teleight/teleightbots/api/methods/SendMessage.java
@@ -4,15 +4,20 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.teleight.teleightbots.api.ApiMethodMessage;
+import org.teleight.teleightbots.api.objects.entities.MessageEntity;
 import org.teleight.teleightbots.api.objects.keyboard.ReplyKeyboard;
 import org.teleight.teleightbots.api.utils.ParseMode;
 
 public record SendMessage(
-        @JsonProperty("chat_id")
+        @JsonProperty(value = "chat_id", required = true)
         @NotNull
         String chatId,
 
-        @JsonProperty("text")
+        @JsonProperty("message_thread_id")
+        @Nullable
+        Integer messageThreadId,
+
+        @JsonProperty(value = "text", required = true)
         @NotNull
         String text,
 
@@ -20,11 +25,25 @@ public record SendMessage(
         @Nullable
         ParseMode parseMode,
 
+        @JsonProperty("entities")
+        @Nullable
+        MessageEntity[] entities,
+
         @JsonProperty("disable_web_page_preview")
-        boolean disableWebPagePreview,
+        Boolean disableWebPagePreview,
 
         @JsonProperty("disable_notification")
-        boolean disableNotification,
+        Boolean disableNotification,
+
+        @JsonProperty("protect_content")
+        Boolean protectContent,
+
+        @JsonProperty("reply_to_message_id")
+        @Nullable
+        Integer replyToMessageId,
+
+        @JsonProperty(value = "allow_sending_without_reply")
+        Boolean allowSendingWithoutReply,
 
         @JsonProperty("reply_markup")
         @Nullable
@@ -47,13 +66,23 @@ public record SendMessage(
             return chatId("" + chatId);
         }
 
+        @NotNull Builder messageThreadId(@Nullable Integer messageThreadId);
+
         @NotNull Builder text(@NotNull String text);
 
         @NotNull Builder parseMode(@Nullable ParseMode parseMode);
 
-        @NotNull Builder disableWebPagePreview(boolean disableWebPagePreview);
+        @NotNull Builder entities(@Nullable MessageEntity[] entities);
 
-        @NotNull Builder disableNotification(boolean disableNotification);
+        @NotNull Builder disableWebPagePreview(Boolean disableWebPagePreview);
+
+        @NotNull Builder disableNotification(Boolean disableNotification);
+
+        @NotNull Builder protectContent(Boolean protectContent);
+
+        @NotNull Builder replyToMessageId(@Nullable Integer replyToMessageId);
+
+        @NotNull Builder allowSendingWithoutReply(Boolean allowSendingWithoutReply);
 
         @NotNull Builder replyMarkup(@Nullable ReplyKeyboard replyMarkup);
 
@@ -62,15 +91,26 @@ public record SendMessage(
 
     static final class BuilderImpl implements Builder {
         private String chatId;
+        private Integer messageThreadId;
         private String text;
         private ParseMode parseMode;
+        private MessageEntity[] entities;
         private boolean disableWebPagePreview;
         private boolean disableNotification;
+        private boolean protectContent;
+        private Integer replyToMessageId;
+        private boolean allowSendingWithoutReply;
         private ReplyKeyboard replyMarkup;
 
         @Override
         public @NotNull Builder chatId(@NotNull String chatId) {
             this.chatId = chatId;
+            return this;
+        }
+
+        @Override
+        public @NotNull Builder messageThreadId(@Nullable Integer messageThreadId) {
+            this.messageThreadId = messageThreadId;
             return this;
         }
 
@@ -87,14 +127,26 @@ public record SendMessage(
         }
 
         @Override
-        public @NotNull Builder disableWebPagePreview(boolean disableWebPagePreview) {
+        public @NotNull Builder entities(@Nullable MessageEntity[] entities) {
+            this.entities = entities;
+            return this;
+        }
+
+        @Override
+        public @NotNull Builder disableWebPagePreview(Boolean disableWebPagePreview) {
             this.disableWebPagePreview = disableWebPagePreview;
             return this;
         }
 
         @Override
-        public @NotNull Builder disableNotification(boolean disableNotification) {
+        public @NotNull Builder disableNotification(Boolean disableNotification) {
             this.disableNotification = disableNotification;
+            return this;
+        }
+
+        @Override
+        public @NotNull Builder protectContent(Boolean protectContent) {
+            this.protectContent = protectContent;
             return this;
         }
 
@@ -105,8 +157,32 @@ public record SendMessage(
         }
 
         @Override
+        public @NotNull Builder replyToMessageId(@Nullable Integer replyToMessageId) {
+            this.replyToMessageId = replyToMessageId;
+            return this;
+        }
+
+        @Override
+        public @NotNull Builder allowSendingWithoutReply(Boolean allowSendingWithoutReply) {
+            this.allowSendingWithoutReply = allowSendingWithoutReply;
+            return this;
+        }
+
+        @Override
         public @NotNull SendMessage build() {
-            return new SendMessage(chatId, text, parseMode, disableWebPagePreview, disableNotification, replyMarkup);
+            return new SendMessage(
+                    chatId,
+                    messageThreadId,
+                    text,
+                    parseMode,
+                    entities,
+                    disableWebPagePreview,
+                    disableNotification,
+                    protectContent,
+                    replyToMessageId,
+                    allowSendingWithoutReply,
+                    replyMarkup
+            );
         }
     }
 

--- a/src/main/java/org/teleight/teleightbots/event/bot/group/BotJoinedGroupEvent.java
+++ b/src/main/java/org/teleight/teleightbots/event/bot/group/BotJoinedGroupEvent.java
@@ -5,7 +5,7 @@ import org.teleight.teleightbots.api.objects.Update;
 import org.teleight.teleightbots.bot.Bot;
 import org.teleight.teleightbots.event.trait.GroupBotEvent;
 
-public record BotJoinGroupEvent(
+public record BotJoinedGroupEvent(
         @NotNull Bot bot,
         @NotNull Update update
 ) implements GroupBotEvent {

--- a/src/main/java/org/teleight/teleightbots/event/bot/group/BotLeftGroupEvent.java
+++ b/src/main/java/org/teleight/teleightbots/event/bot/group/BotLeftGroupEvent.java
@@ -5,7 +5,7 @@ import org.teleight.teleightbots.api.objects.Update;
 import org.teleight.teleightbots.bot.Bot;
 import org.teleight.teleightbots.event.trait.GroupBotEvent;
 
-public record BotQuitGroupEvent(
+public record BotLeftGroupEvent(
         @NotNull Bot bot,
         @NotNull Update update
 ) implements GroupBotEvent {

--- a/src/main/java/org/teleight/teleightbots/event/trait/MessageEvent.java
+++ b/src/main/java/org/teleight/teleightbots/event/trait/MessageEvent.java
@@ -1,0 +1,28 @@
+package org.teleight.teleightbots.event.trait;
+
+import org.jetbrains.annotations.NotNull;
+import org.teleight.teleightbots.api.methods.SendMessage;
+import org.teleight.teleightbots.api.objects.Message;
+import org.teleight.teleightbots.api.objects.Update;
+
+import java.util.concurrent.CompletableFuture;
+
+public interface MessageEvent extends Event {
+
+    Update update();
+
+    default @NotNull CompletableFuture<Message> reply(String text) {
+        final Update update = update();
+        final Message message = update.message();
+        if (message == null || message.chat() == null) {
+            return CompletableFuture.completedFuture(null);
+        }
+        return bot().execute(SendMessage.builder()
+                .text(text)
+                .replyToMessageId(message.messageId())
+                .chatId(message.chat().id())
+                .build()
+        );
+    }
+
+}

--- a/src/main/java/org/teleight/teleightbots/event/user/UserInlineQueryReceivedEvent.java
+++ b/src/main/java/org/teleight/teleightbots/event/user/UserInlineQueryReceivedEvent.java
@@ -1,23 +1,24 @@
 package org.teleight.teleightbots.event.user;
 
 import org.jetbrains.annotations.NotNull;
-import org.teleight.teleightbots.api.objects.Message;
 import org.teleight.teleightbots.api.objects.Update;
+import org.teleight.teleightbots.api.objects.User;
+import org.teleight.teleightbots.api.objects.inline.InlineQuery;
 import org.teleight.teleightbots.bot.Bot;
 import org.teleight.teleightbots.event.trait.Event;
 
-public record UserWriteEvent(
+public record UserInlineQueryReceivedEvent(
         @NotNull Bot bot,
         @NotNull Update update
 ) implements Event {
 
-    @Override
-    public @NotNull Update update() {
-        return update;
+    @NotNull
+    public User user() {
+        return update().inlineQuery().from();
     }
 
-    public Message message(){
-        return update.message();
+    public InlineQuery inlineQuery() {
+        return update().inlineQuery();
     }
 
 }

--- a/src/main/java/org/teleight/teleightbots/event/user/UserMessageReceivedEvent.java
+++ b/src/main/java/org/teleight/teleightbots/event/user/UserMessageReceivedEvent.java
@@ -4,12 +4,12 @@ import org.jetbrains.annotations.NotNull;
 import org.teleight.teleightbots.api.objects.Message;
 import org.teleight.teleightbots.api.objects.Update;
 import org.teleight.teleightbots.bot.Bot;
-import org.teleight.teleightbots.event.trait.Event;
+import org.teleight.teleightbots.event.trait.MessageEvent;
 
 public record UserMessageReceivedEvent(
         @NotNull Bot bot,
         @NotNull Update update
-) implements Event {
+) implements MessageEvent {
 
     @Override
     public @NotNull Update update() {

--- a/src/main/java/org/teleight/teleightbots/event/user/UserMessageReceivedEvent.java
+++ b/src/main/java/org/teleight/teleightbots/event/user/UserMessageReceivedEvent.java
@@ -1,23 +1,23 @@
 package org.teleight.teleightbots.event.user;
 
 import org.jetbrains.annotations.NotNull;
+import org.teleight.teleightbots.api.objects.Message;
 import org.teleight.teleightbots.api.objects.Update;
-import org.teleight.teleightbots.api.objects.User;
-import org.teleight.teleightbots.api.objects.inline.InlineQuery;
 import org.teleight.teleightbots.bot.Bot;
 import org.teleight.teleightbots.event.trait.Event;
 
-public record UserInlineSentEvent(
+public record UserMessageReceivedEvent(
         @NotNull Bot bot,
         @NotNull Update update
 ) implements Event {
 
-    public User user() {
-        return update().inlineQuery().from();
+    @Override
+    public @NotNull Update update() {
+        return update;
     }
 
-    public InlineQuery inlineQuery() {
-        return update().inlineQuery();
+    public Message message(){
+        return update.message();
     }
 
 }

--- a/src/main/java/org/teleight/teleightbots/updateprocessor/LongPollingUpdateProcessor.java
+++ b/src/main/java/org/teleight/teleightbots/updateprocessor/LongPollingUpdateProcessor.java
@@ -19,11 +19,11 @@ import org.teleight.teleightbots.event.bot.UpdateReceivedEvent;
 import org.teleight.teleightbots.event.bot.channel.BotJoinChannelEvent;
 import org.teleight.teleightbots.event.bot.channel.BotQuitChannelEvent;
 import org.teleight.teleightbots.event.bot.channel.ChannelSendMessageEvent;
-import org.teleight.teleightbots.event.bot.group.BotJoinGroupEvent;
-import org.teleight.teleightbots.event.bot.group.BotQuitGroupEvent;
+import org.teleight.teleightbots.event.bot.group.BotJoinedGroupEvent;
+import org.teleight.teleightbots.event.bot.group.BotLeftGroupEvent;
 import org.teleight.teleightbots.event.keyboard.ButtonPressEvent;
-import org.teleight.teleightbots.event.user.UserInlineSentEvent;
-import org.teleight.teleightbots.event.user.UserWriteEvent;
+import org.teleight.teleightbots.event.user.UserInlineQueryReceivedEvent;
+import org.teleight.teleightbots.event.user.UserMessageReceivedEvent;
 import org.teleight.teleightbots.exception.exceptions.RateLimitException;
 import org.teleight.teleightbots.exception.exceptions.TelegramRequestException;
 import org.teleight.teleightbots.utils.MultiPartBodyPublisher;
@@ -162,7 +162,7 @@ public class LongPollingUpdateProcessor implements UpdateProcessor {
 
                         //Write
                         if (hasText && hasFormat) {
-                            bot.getEventManager().call(new UserWriteEvent(bot, update));
+                            bot.getEventManager().call(new UserMessageReceivedEvent(bot, update));
                         }
 
 
@@ -175,7 +175,7 @@ public class LongPollingUpdateProcessor implements UpdateProcessor {
                                     .anyMatch(user -> user.username().equalsIgnoreCase(bot.getBotUsername()));
                             Boolean groupChatCreated = message.groupChatCreated();
                             if (isThisBotJoined || (groupChatCreated != null && groupChatCreated)) {
-                                bot.getEventManager().call(new BotJoinGroupEvent(bot, update));
+                                bot.getEventManager().call(new BotJoinedGroupEvent(bot, update));
                             }
                         }
                     }
@@ -198,7 +198,7 @@ public class LongPollingUpdateProcessor implements UpdateProcessor {
                                 if (isChannel) {
                                     bot.getEventManager().call(new BotJoinChannelEvent(bot, update));
                                 } else {
-                                    bot.getEventManager().call(new BotJoinGroupEvent(bot, update));
+                                    bot.getEventManager().call(new BotJoinedGroupEvent(bot, update));
                                 }
                             }
 
@@ -206,7 +206,7 @@ public class LongPollingUpdateProcessor implements UpdateProcessor {
                                 if (isChannel) {
                                     bot.getEventManager().call(new BotQuitChannelEvent(bot, update));
                                 } else {
-                                    bot.getEventManager().call(new BotQuitGroupEvent(bot, update));
+                                    bot.getEventManager().call(new BotLeftGroupEvent(bot, update));
                                 }
                             }
                         }
@@ -215,7 +215,7 @@ public class LongPollingUpdateProcessor implements UpdateProcessor {
 
                     //Inline
                     if (update.inlineQuery() != null) {
-                        bot.getEventManager().call(new UserInlineSentEvent(bot, update));
+                        bot.getEventManager().call(new UserInlineQueryReceivedEvent(bot, update));
                     }
 
 


### PR DESCRIPTION
Relatively simple PR that creates a `MessageEvent` base interface to deal with replies and other possible actions and addresses some weird event names.

Also adds some missing parameters for the `SendMessage` method