### PR TITLE
Remove static library initializer

### DIFF
--- a/demo/src/main/java/org/teleight/teleightbots/demo/MainDemo.java
+++ b/demo/src/main/java/org/teleight/teleightbots/demo/MainDemo.java
@@ -15,9 +15,6 @@ import org.teleight.teleightbots.menu.Menu;
 public class MainDemo {
 
     public static void main(String[] args) {
-        final TeleightBots teleightBots = TeleightBots.init();
-        teleightBots.start();
-
         final String botToken = System.getenv("bot.token") != null ? System.getenv("bot.token") : "--INSERT-TOKEN-HERE--";
         final String botUsername = System.getenv("bot.username") != null ? System.getenv("bot.username") : "--INSERT-USERNAME--HERE";
         final String chatId = System.getenv("bot.default_chatid") != null ? System.getenv("bot.default_chatid") : "--INSERT-CHATID--HERE";

--- a/src/main/java/org/teleight/teleightbots/TeleightBots.java
+++ b/src/main/java/org/teleight/teleightbots/TeleightBots.java
@@ -6,31 +6,16 @@ import org.teleight.teleightbots.bot.manager.BotManager;
 import org.teleight.teleightbots.exception.ExceptionManager;
 import org.teleight.teleightbots.scheduler.Scheduler;
 
+import java.io.IOException;
+
 public final class TeleightBots {
 
     @ApiStatus.Internal
-    private static TeleightBotsProcess teleightBotsProcess;
+    private static final TeleightBotsProcess teleightBotsProcess;
 
-    /**
-     * Initializes the TeleightBots API.
-     * <p>
-     * This method should be called before any other method from the TeleightBots API.
-     * It initializes the TeleightBots API and returns a new instance of TeleightBots.
-     * This method should be called only once.
-     * </p>
-     *
-     * @return a new instance of TeleightBots
-     */
-    public static @NotNull TeleightBots init() {
-        updateProcess();
-        return new TeleightBots();
-    }
-
-    @ApiStatus.Internal
-    public static TeleightBotsProcess updateProcess() {
-        TeleightBotsProcess process = new TeleightBotsProcessImpl();
-        teleightBotsProcess = process;
-        return process;
+    // Initializes the TeleightBots API
+    static {
+        teleightBotsProcess = new TeleightBotsProcessImpl();
     }
 
     /**
@@ -41,7 +26,11 @@ public final class TeleightBots {
      * </p>
      */
     public static void stopCleanly() {
-        teleightBotsProcess.close();
+        try {
+            teleightBotsProcess.close();
+        } catch (IOException e) {
+            getExceptionManager().handleException(e);
+        }
     }
 
     /**
@@ -79,16 +68,6 @@ public final class TeleightBots {
      */
     public static @NotNull ExceptionManager getExceptionManager() {
         return teleightBotsProcess.exceptionManager();
-    }
-
-    /**
-     * Starts the TeleightBots API.
-     * <p>
-     * This method should be called after the TeleightBots API has been initialized and configured.
-     * </p>
-     */
-    public void start() {
-        teleightBotsProcess.start();
     }
 
 }

--- a/src/main/java/org/teleight/teleightbots/TeleightBotsProcess.java
+++ b/src/main/java/org/teleight/teleightbots/TeleightBotsProcess.java
@@ -5,16 +5,15 @@ import org.teleight.teleightbots.bot.manager.BotManager;
 import org.teleight.teleightbots.exception.ExceptionManager;
 import org.teleight.teleightbots.scheduler.Scheduler;
 
-public sealed interface TeleightBotsProcess permits TeleightBotsProcessImpl {
+import java.io.Closeable;
 
-    void start();
-
-    void close();
+public sealed interface TeleightBotsProcess extends Closeable permits TeleightBotsProcessImpl {
 
     @NotNull Scheduler scheduler();
 
     @NotNull BotManager botManager();
 
-    @NotNull ExceptionManager exceptionManager();
+    @NotNull
+    ExceptionManager exceptionManager();
 
 }

--- a/src/main/java/org/teleight/teleightbots/TeleightBotsProcessImpl.java
+++ b/src/main/java/org/teleight/teleightbots/TeleightBotsProcessImpl.java
@@ -7,39 +7,43 @@ import org.teleight.teleightbots.exception.ExceptionManager;
 import org.teleight.teleightbots.scheduler.Scheduler;
 import org.teleight.teleightbots.scheduler.SchedulerImpl;
 
+import java.io.IOException;
+
 final class TeleightBotsProcessImpl implements TeleightBotsProcess {
 
-    private final SchedulerImpl schedulerImpl;
-    private final BotManagerImpl botManagerImpl;
+    private final Scheduler scheduler;
+    private final BotManager botManager;
     private final ExceptionManager exceptionManager;
 
     public TeleightBotsProcessImpl() {
-        schedulerImpl = new SchedulerImpl();
-        botManagerImpl = new BotManagerImpl();
+        scheduler = new SchedulerImpl();
+        botManager = new BotManagerImpl();
         exceptionManager = new ExceptionManager();
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            try {
+                this.close();
+            } catch (IOException e) {
+                TeleightBots.getExceptionManager().handleException(e);
+            }
+        }));
     }
 
     @Override
-    public void start() {
-        System.out.println("Started Teleight");
-        Runtime.getRuntime().addShutdownHook(new Thread(this::close));
-    }
-
-    @Override
-    public void close() {
+    public void close() throws IOException {
         System.out.println("Shutting down Teleight");
-        botManagerImpl.close();
-        schedulerImpl.close();
+        botManager.close();
+        scheduler.close();
     }
 
     @Override
     public @NotNull Scheduler scheduler() {
-        return schedulerImpl;
+        return scheduler;
     }
 
     @Override
     public @NotNull BotManager botManager() {
-        return botManagerImpl;
+        return botManager;
     }
 
     @Override

--- a/src/main/java/org/teleight/teleightbots/bot/manager/BotManagerImpl.java
+++ b/src/main/java/org/teleight/teleightbots/bot/manager/BotManagerImpl.java
@@ -10,6 +10,7 @@ import org.teleight.teleightbots.bot.TelegramBotImpl;
 import org.teleight.teleightbots.updateprocessor.LongPollingUpdateProcessor;
 import org.teleight.teleightbots.updateprocessor.UpdateProcessor;
 
+import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -48,7 +49,7 @@ public final class BotManagerImpl implements BotManager {
     }
 
     @Override
-    public void close() {
+    public void close() throws IOException {
         for (final TelegramBot registeredBot : registeredBots) {
             registeredBot.shutdown();
         }

--- a/src/main/java/org/teleight/teleightbots/scheduler/SchedulerImpl.java
+++ b/src/main/java/org/teleight/teleightbots/scheduler/SchedulerImpl.java
@@ -3,6 +3,7 @@ package org.teleight.teleightbots.scheduler;
 import org.jetbrains.annotations.NotNull;
 import org.teleight.teleightbots.TeleightBots;
 
+import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -58,7 +59,7 @@ public class SchedulerImpl implements Scheduler {
     }
 
     @Override
-    public void close() {
+    public void close() throws IOException {
         System.out.println("Closing Scheduler");
 
         EXECUTOR.shutdown();


### PR DESCRIPTION
### Breaking change!

I feel like the TeleightBots#init method is just redundant and could be changed with a simpler static initializer. Developers don't need to init and start the library anymore - that is now automated

The start method was also pretty much redundant since the only thing it did was to create a shutdown hook. That could be easily implemented inside the `TeleightBotsProcessImpl` constructor