### PR TITLE
Conversation refactor, custom properties

### DIFF
--- a/demo/src/main/java/org/teleight/teleightbots/demo/MainDemo.java
+++ b/demo/src/main/java/org/teleight/teleightbots/demo/MainDemo.java
@@ -5,6 +5,9 @@ import org.teleight.teleightbots.api.methods.SendMessage;
 import org.teleight.teleightbots.api.objects.InlineKeyboardButton;
 import org.teleight.teleightbots.api.objects.ParseMode;
 import org.teleight.teleightbots.bot.settings.BotSettings;
+import org.teleight.teleightbots.conversation.Conversation;
+import org.teleight.teleightbots.conversation.ConversationInstanceConstraints;
+import org.teleight.teleightbots.conversation.Property;
 import org.teleight.teleightbots.demo.command.TestCommand;
 import org.teleight.teleightbots.demo.command.TestConversationCommand;
 import org.teleight.teleightbots.demo.conversations.TestConversation;
@@ -64,7 +67,13 @@ public class MainDemo {
                     .build();
             bot.execute(sendMessage);
 
-            bot.getConversationManager().registerConversation(new TestConversation());
+            Conversation testConversation = Conversation.ofBuilder("test", new TestConversation())
+                    .property(Property.of("test"))
+                    .allowUnknownProperties(true)
+                    .instanceConstraints(ConversationInstanceConstraints.ofBuilder().maxInstances(1).build())
+                    .build();
+            bot.getConversationManager().registerConversation(testConversation);
+
             bot.getCommandManager().registerCommand(new TestConversationCommand());
         });
     }

--- a/demo/src/main/java/org/teleight/teleightbots/demo/command/TestConversationCommand.java
+++ b/demo/src/main/java/org/teleight/teleightbots/demo/command/TestConversationCommand.java
@@ -1,6 +1,9 @@
 package org.teleight.teleightbots.demo.command;
 
 import org.teleight.teleightbots.commands.builder.Command;
+import org.teleight.teleightbots.conversation.ConversationManager;
+
+import java.util.Map;
 
 public class TestConversationCommand extends Command {
 
@@ -17,7 +20,19 @@ public class TestConversationCommand extends Command {
                 return;
             }
 
-            context.bot().getConversationManager().joinConversation(sender, context.message().chat(), conversationName);
+            Map<String, Object> properties = Map.of(
+                    "test", "John",
+                    "age", 25
+            );
+            ConversationManager.JoinResult result = context.bot().getConversationManager().joinConversation(
+                    sender, context.message().chat(), conversationName, properties);
+            if (result instanceof ConversationManager.JoinResult.AlreadyInConversation) {
+                System.out.println("User is already in conversation");
+            } else if (result instanceof ConversationManager.JoinResult.ConversationNotFound) {
+                System.out.println("Conversation not found");
+            } else {
+                System.out.println("Conversation started");
+            }
         });
     }
 

--- a/demo/src/main/java/org/teleight/teleightbots/demo/conversations/TestConversation.java
+++ b/demo/src/main/java/org/teleight/teleightbots/demo/conversations/TestConversation.java
@@ -5,12 +5,12 @@ import org.teleight.teleightbots.api.methods.SendMessage;
 import org.teleight.teleightbots.api.objects.Chat;
 import org.teleight.teleightbots.api.objects.Message;
 import org.teleight.teleightbots.api.objects.Update;
-import org.teleight.teleightbots.conversation.Conversation;
 import org.teleight.teleightbots.conversation.ConversationContext;
+import org.teleight.teleightbots.conversation.ConversationExecutor;
 
 import java.util.concurrent.TimeUnit;
 
-public class TestConversation implements Conversation {
+public class TestConversation implements ConversationExecutor {
 
     @Override
     public void execute(@NotNull ConversationContext context) {
@@ -47,18 +47,13 @@ public class TestConversation implements Conversation {
         System.out.println("Message: " + message.text());
 
         // Now, check if the text equals hello or not and act appropriately
+        SendMessage resultToUser;
         if (message.text() == null || !message.text().equals("hello")) {
-            SendMessage resultToUser = SendMessage.ofBuilder(chatId, "You didn't send \"hello\"!").build();
-            context.bot().execute(resultToUser);
+            resultToUser = SendMessage.ofBuilder(chatId, "You didn't send \"hello\"!").build();
         } else {
-            SendMessage resultToUser = SendMessage.ofBuilder(chatId, "Good job!").build();
-            context.bot().execute(resultToUser);
+            resultToUser = SendMessage.ofBuilder(chatId, "Good job!").build();
         }
-    }
-
-    @Override
-    public @NotNull String name() {
-        return "test";
+        context.bot().execute(resultToUser);
     }
 
 }

--- a/src/main/java/org/teleight/teleightbots/conversation/Conversation.java
+++ b/src/main/java/org/teleight/teleightbots/conversation/Conversation.java
@@ -1,32 +1,57 @@
 package org.teleight.teleightbots.conversation;
 
-import org.jetbrains.annotations.NotNull;
+import lombok.Builder;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
- * The {@code Conversation} interface represents a structured interaction between a bot and a user.
+ * A conversation represents a structured interaction between a bot and a user.
  * <p>
  * A conversation typically follows a sequence of exchanges (messages) where the bot prompts
  * the user for input, processes the response, and decides on the next step.
  * <p>
  * A unique name identifies each conversation.
  *
+ * @param name                   the name of the conversation, used to identify the conversation. Must be unique.
+ * @param executor               the executor of the conversation, see {@link ConversationExecutor}
+ * @param properties             the properties of the conversation
+ * @param instanceConstraints    the constraints of the conversation instance, see {@link ConversationInstanceConstraints}
+ * @param allowUnknownProperties whether unknown properties are allowed.
+ *                               By default, unknown properties are not allowed and will throw an exception.
  * @see ConversationManager#registerConversation(Conversation)
  */
-public interface Conversation {
+@Builder(builderClassName = "Builder", toBuilder = true, builderMethodName = "ofBuilder")
+public record Conversation(
+        String name,
+        ConversationExecutor executor,
+        Map<String, Property<?>> properties,
+        ConversationInstanceConstraints instanceConstraints,
+        boolean allowUnknownProperties
+) {
 
-    /**
-     * Executes the conversation logic within the provided context.
-     *
-     * @param context The context in which the conversation is executed.
-     */
-    void execute(@NotNull ConversationContext context);
+    public static Conversation.Builder ofBuilder(String name, ConversationExecutor executor) {
+        return new Builder().name(name).executor(executor);
+    }
 
-    /**
-     * Returns the unique name of the conversation.
-     * This name is used to identify the conversation and should be descriptive of its purpose or function.
-     *
-     * @return The name of the conversation.
-     */
-    @NotNull String name();
+    public static class Builder {
+        Builder() {
+            properties = new HashMap<>();
+            instanceConstraints = ConversationInstanceConstraints.ofBuilder().build();
+        }
+
+        @lombok.experimental.Tolerate
+        public Builder property(Property<?> property) {
+            properties.put(property.name(), property);
+            return this;
+        }
+
+        @lombok.experimental.Tolerate
+        public Builder properties(List<Property<?>> properties) {
+            properties.forEach(this::property);
+            return this;
+        }
+    }
 
 }

--- a/src/main/java/org/teleight/teleightbots/conversation/ConversationContext.java
+++ b/src/main/java/org/teleight/teleightbots/conversation/ConversationContext.java
@@ -80,7 +80,7 @@ public class ConversationContext {
         // Apply the properties registered with the conversation
         conversation.properties().forEach((name, property) -> {
             if (properties != null && properties.containsKey(name)) {
-                applyProperty(name, property.value());
+                applyProperty(name, properties.get(name));
             } else if (property.required()) {
                 throw new IllegalArgumentException("The conversation " + conversation.name() + " requires a non-null value for the property " + property.name());
             }

--- a/src/main/java/org/teleight/teleightbots/conversation/ConversationContext.java
+++ b/src/main/java/org/teleight/teleightbots/conversation/ConversationContext.java
@@ -3,6 +3,7 @@ package org.teleight.teleightbots.conversation;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.Unmodifiable;
 import org.teleight.teleightbots.api.objects.Chat;
 import org.teleight.teleightbots.api.objects.Update;
 import org.teleight.teleightbots.api.objects.User;
@@ -112,6 +113,13 @@ public class ConversationContext {
      */
     public @Nullable Property<?> getProperty(@NotNull String name) {
         return appliedProperties.get(name);
+    }
+
+    /**
+     * @return A map of all properties applied to the conversation.
+     */
+    public @Unmodifiable Map<String, Property<?>> getProperties() {
+        return appliedProperties;
     }
 
     /**

--- a/src/main/java/org/teleight/teleightbots/conversation/ConversationExecutor.java
+++ b/src/main/java/org/teleight/teleightbots/conversation/ConversationExecutor.java
@@ -1,0 +1,25 @@
+package org.teleight.teleightbots.conversation;
+
+/**
+ * Represents an executor for a conversation.
+ *
+ * <p>
+ * Example usage:
+ * <pre>{@code
+ * Conversation testConversation = Conversation.ofBuilder("test", context -> {
+ *      String id = context.chat().id();
+ *      SendMessage message = SendMessage.ofBuilder(id, "Test conversation").build();
+ *      context.bot().execute(message);
+ * }).build();
+ * }</pre>
+ */
+public interface ConversationExecutor {
+
+    /**
+     * Executes the conversation flow.
+     *
+     * @param context the context of the currently running conversation
+     */
+    void execute(ConversationContext context);
+
+}

--- a/src/main/java/org/teleight/teleightbots/conversation/ConversationExecutor.java
+++ b/src/main/java/org/teleight/teleightbots/conversation/ConversationExecutor.java
@@ -1,5 +1,7 @@
 package org.teleight.teleightbots.conversation;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Represents an executor for a conversation.
  *
@@ -13,6 +15,7 @@ package org.teleight.teleightbots.conversation;
  * }).build();
  * }</pre>
  */
+@FunctionalInterface
 public interface ConversationExecutor {
 
     /**
@@ -20,6 +23,6 @@ public interface ConversationExecutor {
      *
      * @param context the context of the currently running conversation
      */
-    void execute(ConversationContext context);
+    void execute(@NotNull ConversationContext context);
 
 }

--- a/src/main/java/org/teleight/teleightbots/conversation/ConversationInstanceConstraints.java
+++ b/src/main/java/org/teleight/teleightbots/conversation/ConversationInstanceConstraints.java
@@ -1,0 +1,36 @@
+package org.teleight.teleightbots.conversation;
+
+import lombok.Builder;
+
+/**
+ * Represents constraints for a conversation instance.
+ * <p>
+ * The constraints define the maximum number of instances that can be created for a conversation.
+ *
+ * @param maxInstances               the maximum number of instances that can be created for a conversation
+ *                                   (default is -1, which means no limit)
+ * @param maxInstancesPerUser        the maximum number of instances that can be created per user
+ *                                   (default is -1, which means no limit)
+ * @param maxInstancesPerChat        the maximum number of instances that can be created per chat
+ *                                   (default is -1, which means no limit)
+ * @param maxInstancesPerUserPerChat the maximum number of instances that can be created per user in a chat
+ *                                   (default is -1, which means no limit)
+ */
+@Builder(builderClassName = "Builder", toBuilder = true, builderMethodName = "ofBuilder")
+public record ConversationInstanceConstraints(
+        int maxInstances,
+        int maxInstancesPerUser,
+        int maxInstancesPerChat,
+        int maxInstancesPerUserPerChat
+) {
+
+    public static class Builder {
+        Builder() {
+            maxInstances = -1;
+            maxInstancesPerUser = -1;
+            maxInstancesPerChat = -1;
+            maxInstancesPerUserPerChat = -1;
+        }
+    }
+
+}

--- a/src/main/java/org/teleight/teleightbots/conversation/ConversationManager.java
+++ b/src/main/java/org/teleight/teleightbots/conversation/ConversationManager.java
@@ -8,6 +8,7 @@ import org.teleight.teleightbots.api.objects.User;
 import org.teleight.teleightbots.bot.TelegramBot;
 
 import java.util.Collection;
+import java.util.Map;
 
 /**
  * This is an interface for a ConversationManager. It provides methods to manage conversations.
@@ -42,10 +43,24 @@ public sealed interface ConversationManager permits ConversationManagerImpl {
      * @param chat             The Chat where the conversation is taking place.
      * @param conversationName The name of the Conversation the user wants to join.
      *                         This should match the name returned by {@link Conversation#name()}.
-     * @throws IllegalStateException    if the user is already in a conversation.
+     * @throws IllegalStateException    if the user is already in a conversation or the conversation does not allow multiple instances.
      * @throws IllegalArgumentException if the conversation does not exist.
      */
     void joinConversation(@NotNull User user, @NotNull Chat chat, @NotNull String conversationName);
+
+    /**
+     * Allows a user to join a registered conversation in a specified chat with custom properties.
+     *
+     * @param user             The User who is joining the Conversation.
+     * @param chat             The Chat where the conversation is taking place.
+     * @param conversationName The name of the Conversation the user wants to join.
+     *                         This should match the name returned by {@link Conversation#name()}.
+     * @param properties       A list of custom properties to be passed to the conversation.
+     *                         This can be used to pass additional information to the conversation.
+     * @throws IllegalStateException    if the user is already in a conversation or the conversation does not allow multiple instances.
+     * @throws IllegalArgumentException if the conversation does not exist.
+     */
+    void joinConversation(@NotNull User user, @NotNull Chat chat, @NotNull String conversationName, @Nullable Map<String, Object> properties);
 
     /**
      * Allows a user to forcefully leave an active conversation.

--- a/src/main/java/org/teleight/teleightbots/conversation/ConversationManager.java
+++ b/src/main/java/org/teleight/teleightbots/conversation/ConversationManager.java
@@ -43,10 +43,9 @@ public sealed interface ConversationManager permits ConversationManagerImpl {
      * @param chat             The Chat where the conversation is taking place.
      * @param conversationName The name of the Conversation the user wants to join.
      *                         This should match the name returned by {@link Conversation#name()}.
-     * @throws IllegalStateException    if the user is already in a conversation or the conversation does not allow multiple instances.
-     * @throws IllegalArgumentException if the conversation does not exist.
+     * @return A {@link JoinResult} indicating the result of the join operation.
      */
-    void joinConversation(@NotNull User user, @NotNull Chat chat, @NotNull String conversationName);
+    JoinResult joinConversation(@NotNull User user, @NotNull Chat chat, @NotNull String conversationName);
 
     /**
      * Allows a user to join a registered conversation in a specified chat with custom properties.
@@ -57,10 +56,9 @@ public sealed interface ConversationManager permits ConversationManagerImpl {
      *                         This should match the name returned by {@link Conversation#name()}.
      * @param properties       A list of custom properties to be passed to the conversation.
      *                         This can be used to pass additional information to the conversation.
-     * @throws IllegalStateException    if the user is already in a conversation or the conversation does not allow multiple instances.
-     * @throws IllegalArgumentException if the conversation does not exist.
+     * @return A {@link JoinResult} indicating the result of the join operation.
      */
-    void joinConversation(@NotNull User user, @NotNull Chat chat, @NotNull String conversationName, @Nullable Map<String, Object> properties);
+    JoinResult joinConversation(@NotNull User user, @NotNull Chat chat, @NotNull String conversationName, @Nullable Map<String, Object> properties);
 
     /**
      * Allows a user to forcefully leave an active conversation.
@@ -110,4 +108,37 @@ public sealed interface ConversationManager permits ConversationManagerImpl {
     @Unmodifiable
     Collection<ConversationContext> getRunningConversations();
 
+    /**
+     * Represents the result of a join operation.
+     */
+    sealed interface JoinResult permits
+            JoinResult.AlreadyInConversation,
+            JoinResult.ConversationNotFound,
+            JoinResult.InstanceConstraintReached,
+            JoinResult.Success {
+
+        /**
+         * Represents a successful join operation.
+         */
+        record Success() implements JoinResult {
+        }
+
+        /**
+         * Represents a failed join operation due to the user already being in a conversation.
+         */
+        record AlreadyInConversation() implements JoinResult {
+        }
+
+        /**
+         * Represents a failed join operation due to the conversation not being found.
+         */
+        record ConversationNotFound() implements JoinResult {
+        }
+
+        /**
+         * Represents a failed join operation due to the maximum instance constraint being reached.
+         */
+        record InstanceConstraintReached(String constraint) implements JoinResult {
+        }
+    }
 }

--- a/src/main/java/org/teleight/teleightbots/conversation/ConversationManagerImpl.java
+++ b/src/main/java/org/teleight/teleightbots/conversation/ConversationManagerImpl.java
@@ -1,6 +1,7 @@
 package org.teleight.teleightbots.conversation;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.Unmodifiable;
 import org.teleight.teleightbots.api.objects.Chat;
 import org.teleight.teleightbots.api.objects.User;
@@ -10,6 +11,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Predicate;
 
 public final class ConversationManagerImpl implements ConversationManager {
 
@@ -40,6 +42,11 @@ public final class ConversationManagerImpl implements ConversationManager {
 
     @Override
     public void joinConversation(@NotNull User user, @NotNull Chat chat, @NotNull String conversationName) {
+        joinConversation(user, chat, conversationName, null);
+    }
+
+    @Override
+    public void joinConversation(@NotNull User user, @NotNull Chat chat, @NotNull String conversationName, @Nullable Map<String, Object> properties) {
         final long userId = user.id();
         final Conversation conversation = conversations.get(conversationName);
         if (usersInConversation.containsKey(userId)) {
@@ -48,7 +55,41 @@ public final class ConversationManagerImpl implements ConversationManager {
         if (conversation == null) {
             throw new IllegalArgumentException("The conversation " + conversationName + " has not been registered");
         }
-        usersInConversation.put(userId, new ConversationContext(bot, chat, user, conversation));
+
+        checkMaxInstances(conversation, conversationName, chat, user);
+
+        usersInConversation.put(userId, new ConversationContext(bot, chat, user, conversation, properties));
+    }
+
+    private void checkMaxInstances(Conversation conversation, String conversationName, Chat chat, User user) {
+        final long userId = user.id();
+        final String chatId = chat.id();
+
+        checkInstanceLimit(
+                "instance", conversation.instanceConstraints().maxInstances(),
+                (ctx) -> ctx.conversation().name().equals(conversationName)
+        );
+        checkInstanceLimit(
+                "user", conversation.instanceConstraints().maxInstancesPerUser(),
+                (ctx) -> ctx.conversation().name().equals(conversationName) && ctx.user().id() == userId
+        );
+        checkInstanceLimit(
+                "chat", conversation.instanceConstraints().maxInstancesPerChat(),
+                (ctx) -> ctx.conversation().name().equals(conversationName) && ctx.chat().id().equals(chatId)
+        );
+        checkInstanceLimit(
+                "user in chat", conversation.instanceConstraints().maxInstancesPerUserPerChat(),
+                (ctx) -> ctx.conversation().name().equals(conversationName) && ctx.user().id() == userId && ctx.chat().id().equals(chatId)
+        );
+    }
+
+    private void checkInstanceLimit(String context, int limit, Predicate<ConversationContext> predicate) {
+        if (limit != -1) {
+            long instances = usersInConversation.values().stream().filter(predicate).count();
+            if (instances >= limit) {
+                throw new IllegalStateException("The conversation " + context + " constraint has been reached");
+            }
+        }
     }
 
     @Override

--- a/src/main/java/org/teleight/teleightbots/conversation/Property.java
+++ b/src/main/java/org/teleight/teleightbots/conversation/Property.java
@@ -1,0 +1,102 @@
+package org.teleight.teleightbots.conversation;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a custom property that can be used in a conversation.
+ *
+ * @param <T>      the type of the property value.
+ * @param name     the name of the property. Cannot be null.
+ * @param value    the value of the property.
+ * @param required whether the property is required or not.
+ * @see Property#of(String)
+ * @see Property#of(String, Object)
+ */
+public record Property<T>(
+        @NotNull String name,
+        T value,
+        boolean required
+) {
+
+    /**
+     * Creates a new property with the given name.
+     * The returned property will have a null value and will be required.
+     *
+     * @param name the name of the property. Cannot be null.
+     * @return a new property with the given name.
+     */
+    public static Property<Integer> of(@NotNull String name) {
+        return new Property<>(name, null, true);
+    }
+
+    /**
+     * Creates a new property with the given name and value.
+     *
+     * @param name  the name of the property. Cannot be null.
+     * @param value the value of the property.
+     * @return a new property with the given name and value.
+     */
+    public static <T> Property<T> of(String name, T value) {
+        return new Property<>(name, value, false);
+    }
+
+    /**
+     * Returns the value of the property as a string.
+     *
+     * @return the value of the property as a string.
+     */
+    public String asString() {
+        return value.toString();
+    }
+
+    /**
+     * Returns the value of the property as an integer.
+     *
+     * @return the value of the property as an integer.
+     * @throws ClassCastException if the value cannot be cast to an integer.
+     */
+    public int asInt() {
+        return (int) value;
+    }
+
+    /**
+     * Returns the value of the property as a boolean.
+     *
+     * @return the value of the property as a boolean.
+     * @throws ClassCastException if the value cannot be cast to a boolean.
+     */
+    public boolean asBool() {
+        return (boolean) value;
+    }
+
+    /**
+     * Returns the value of the property as a long.
+     *
+     * @return the value of the property as a long.
+     * @throws ClassCastException if the value cannot be cast to a long.
+     */
+    public long asLong() {
+        return (long) value;
+    }
+
+    /**
+     * Returns the value of the property as a double.
+     *
+     * @return the value of the property as a double.
+     * @throws ClassCastException if the value cannot be cast to a double.
+     */
+    public float asFloat() {
+        return (float) value;
+    }
+
+    /**
+     * Returns the value of the property as a custom type.
+     *
+     * @return the value of the property as a custom type.
+     * @throws ClassCastException if the value cannot be cast to a custom type.
+     */
+    public <A> A as(Class<? extends A> type) {
+        return type.cast(value);
+    }
+
+}


### PR DESCRIPTION
- The `Conversation` class is now a record containing specific information about the conversation
- The executor has been moved from `Conversation` to a new class called `ConversationExecutor`
- Add new parameters to the conversation:
    - properties: conversation-specific properties that can be overridden when calling `ConversationManager#joinConversation`
    - instanceConstraints: the maximum number of instances that can be created for a conversation
    - allowUnknownProperties: allow applying custom properties even if they are not registered
- `ConversationManager#joinConversation` will now return a `JoinResult` instead of throwing exceptions in case of an error