### PR TITLE
Update processor execution refactor

### DIFF
--- a/demo/build.gradle.kts
+++ b/demo/build.gradle.kts
@@ -1,5 +1,7 @@
 plugins {
     id("java")
+    id("application")
+    id("com.github.johnrengelman.shadow") version "8.1.1"
 }
 
 repositories {
@@ -15,4 +17,8 @@ dependencies {
 
 tasks.withType<Javadoc> {
     exclude("**")
+}
+
+application {
+    mainClass.set("org.teleight.teleightbots.demo.MainDemo")
 }

--- a/demo/src/main/java/org/teleight/teleightbots/demo/MainDemo.java
+++ b/demo/src/main/java/org/teleight/teleightbots/demo/MainDemo.java
@@ -18,9 +18,9 @@ import org.teleight.teleightbots.menu.Menu;
 public class MainDemo {
 
     public static void main(String[] args) {
-        final String botToken = System.getenv("bot.token") != null ? System.getenv("bot.token") : "--INSERT-TOKEN-HERE--";
-        final String botUsername = System.getenv("bot.username") != null ? System.getenv("bot.username") : "--INSERT-USERNAME--HERE";
-        final String chatId = System.getenv("bot.default_chatid") != null ? System.getenv("bot.default_chatid") : "--INSERT-CHATID--HERE";
+        final String botToken = System.getenv("bot_token") != null ? System.getenv("bot_token") : "--INSERT-TOKEN-HERE--";
+        final String botUsername = System.getenv("bot_username") != null ? System.getenv("bot_username") : "--INSERT-USERNAME--HERE";
+        final String chatId = System.getenv("bot_default_chatid") != null ? System.getenv("bot_default_chatid") : "--INSERT-CHATID--HERE";
 
         final EventListener<UpdateReceivedEvent> updateEvent = EventListener.ofBuilder(UpdateReceivedEvent.class)
                 .handler(event -> System.out.println("UpdateReceivedEvent: " + event.bot().getBotUsername() + " -> " + event))

--- a/src/main/java/org/teleight/teleightbots/bot/TelegramBot.java
+++ b/src/main/java/org/teleight/teleightbots/bot/TelegramBot.java
@@ -35,14 +35,6 @@ import java.util.concurrent.CompletableFuture;
 public sealed interface TelegramBot permits TelegramBotImpl {
 
     /**
-     * Connects the bot to the Telegram Bot API.
-     * <p>
-     * This method should be called after the bot has been initialized and configured.
-     * </p>
-     */
-    void connect();
-
-    /**
      * Closes the bot from the Telegram Bot API.
      * <p>
      * This method will also close all attached processors to the specified bot instance

--- a/src/main/java/org/teleight/teleightbots/bot/manager/BotManagerImpl.java
+++ b/src/main/java/org/teleight/teleightbots/bot/manager/BotManagerImpl.java
@@ -33,16 +33,7 @@ public final class BotManagerImpl implements BotManager {
         final TelegramBot bot = botProvider.provide(token, username, updateProcessor, botSettings);
 
         updateProcessor.setBot(bot);
-        updateProcessor.start().whenComplete((user, throwable) -> {
-            if (throwable != null) {
-                System.out.println("Error while starting the bot: " + bot.getBotUsername());
-                if (botSettings.silentlyThrowMethodExecution()) {
-                    TeleightBots.getExceptionManager().handleException(throwable);
-                }
-                bot.shutdown();
-                return;
-            }
-
+        updateProcessor.start().thenRun(() -> {
             if (botSettings.extensionsEnabled()) {
                 bot.getExtensionManager().start();
             }

--- a/src/main/java/org/teleight/teleightbots/bot/manager/BotManagerImpl.java
+++ b/src/main/java/org/teleight/teleightbots/bot/manager/BotManagerImpl.java
@@ -4,9 +4,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Unmodifiable;
 import org.teleight.teleightbots.TeleightBots;
 import org.teleight.teleightbots.bot.BotProvider;
-import org.teleight.teleightbots.bot.settings.BotSettings;
 import org.teleight.teleightbots.bot.TelegramBot;
 import org.teleight.teleightbots.bot.TelegramBotImpl;
+import org.teleight.teleightbots.bot.settings.BotSettings;
 import org.teleight.teleightbots.updateprocessor.LongPollingUpdateProcessor;
 import org.teleight.teleightbots.updateprocessor.UpdateProcessor;
 
@@ -33,14 +33,27 @@ public final class BotManagerImpl implements BotManager {
         final TelegramBot bot = botProvider.provide(token, username, updateProcessor, botSettings);
 
         updateProcessor.setBot(bot);
-        bot.connect();
+        updateProcessor.start().whenComplete((user, throwable) -> {
+            if (throwable != null) {
+                System.out.println("Error while starting the bot: " + bot.getBotUsername());
+                if (botSettings.silentlyThrowMethodExecution()) {
+                    TeleightBots.getExceptionManager().handleException(throwable);
+                }
+                bot.shutdown();
+                return;
+            }
 
-        registeredBots.add(bot);
-        try {
-            completeCallback.accept(bot);
-        } catch (Throwable t) {
-            TeleightBots.getExceptionManager().handleException(t);
-        }
+            if (botSettings.extensionsEnabled()) {
+                bot.getExtensionManager().start();
+            }
+
+            registeredBots.add(bot);
+            try {
+                completeCallback.accept(bot);
+            } catch (Throwable t) {
+                TeleightBots.getExceptionManager().handleException(t);
+            }
+        });
     }
 
     @Override

--- a/src/main/java/org/teleight/teleightbots/bot/settings/BotSettings.java
+++ b/src/main/java/org/teleight/teleightbots/bot/settings/BotSettings.java
@@ -47,7 +47,7 @@ public record BotSettings(
      *     <li>{@link #endpointUrl} is set to {@link #DEFAULT_BOT_API_URL}</li>
      *     <li>{@link #updatesLimit} is set to 50</li>
      *     <li>{@link #updatesTimeout} is set to 100</li>
-     *     <li>{@link #silentlyThrowMethodExecution} is set to {@code false}</li>
+     *     <li>{@link #silentlyThrowMethodExecution} is set to {@code true}</li>
      *     <li>{@link #extensionsEnabled} is set to {@code false}</li>
      * </ul>
      */
@@ -64,7 +64,7 @@ public record BotSettings(
                 .endpointUrl(DEFAULT_BOT_API_URL)
                 .updatesLimit(50)
                 .updatesTimeout(100)
-                .silentlyThrowMethodExecution(false)
+                .silentlyThrowMethodExecution(true)
                 .extensionsEnabled(false);
     }
 

--- a/src/main/java/org/teleight/teleightbots/updateprocessor/LongPollingUpdateProcessor.java
+++ b/src/main/java/org/teleight/teleightbots/updateprocessor/LongPollingUpdateProcessor.java
@@ -74,6 +74,11 @@ public class LongPollingUpdateProcessor implements UpdateProcessor {
         return bot.execute(new GetMe())
                 .whenComplete((user, throwable) -> {
                     if (throwable != null) {
+                        System.out.println("Error while authenticating the bot: " + bot.getBotUsername());
+                        if (bot.getBotSettings().silentlyThrowMethodExecution()) {
+                            TeleightBots.getExceptionManager().handleException(throwable);
+                        }
+                        bot.shutdown();
                         return;
                     }
                     System.out.println("Bot authenticated: " + user.username());

--- a/src/main/java/org/teleight/teleightbots/updateprocessor/UpdateProcessor.java
+++ b/src/main/java/org/teleight/teleightbots/updateprocessor/UpdateProcessor.java
@@ -2,6 +2,7 @@ package org.teleight.teleightbots.updateprocessor;
 
 import org.jetbrains.annotations.NotNull;
 import org.teleight.teleightbots.api.ApiMethod;
+import org.teleight.teleightbots.api.objects.User;
 import org.teleight.teleightbots.bot.TelegramBot;
 
 import java.io.Closeable;
@@ -9,7 +10,7 @@ import java.util.concurrent.CompletableFuture;
 
 public interface UpdateProcessor extends Closeable {
 
-    void start();
+    CompletableFuture<User> start();
 
     @NotNull CompletableFuture<String> executeMethod(@NotNull ApiMethod<?> method);
 


### PR DESCRIPTION
- Removed `TelegramBot#start`. The start logic is now implemented inside the bot manager
- Fixed method execution not actually throwing errors inside the completable future
- Do not register the bot if it fails to connect to the bot API