### PR TITLE
fix: make `sendMediaGroup` actually work

### DIFF
--- a/src/main/java/org/teleight/teleightbots/api/methods/SendMediaGroup.java
+++ b/src/main/java/org/teleight/teleightbots/api/methods/SendMediaGroup.java
@@ -5,9 +5,11 @@ import lombok.Builder;
 import lombok.extern.jackson.Jacksonized;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.teleight.teleightbots.api.MultiPartApiMethodMessage;
-import org.teleight.teleightbots.api.objects.InputFile;
+import org.teleight.teleightbots.api.MultiPartApiMethod;
+import org.teleight.teleightbots.api.objects.InputMedia;
+import org.teleight.teleightbots.api.objects.Message;
 import org.teleight.teleightbots.api.objects.ReplyParameters;
+import org.teleight.teleightbots.exception.exceptions.TelegramRequestException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,7 +33,7 @@ public record SendMediaGroup(
 
         @JsonProperty(value = "media", required = true)
         @NotNull
-        InputFile media,
+        InputMedia[] media,
 
         @JsonProperty(value = "disable_notification")
         boolean disableNotification,
@@ -48,15 +50,20 @@ public record SendMediaGroup(
         @JsonProperty(value = "reply_parameters")
         @Nullable
         ReplyParameters replyParameters
-) implements MultiPartApiMethodMessage {
+) implements MultiPartApiMethod<Message[]> {
 
-    public static @NotNull Builder ofBuilder(String chatId, InputFile media) {
+    public static @NotNull Builder ofBuilder(String chatId, InputMedia[] media) {
         return new SendMediaGroup.Builder().chatId(chatId).media(media);
     }
 
     @Override
     public @NotNull String getEndpointURL() {
         return "sendMediaGroup";
+    }
+
+    @Override
+    public @NotNull Message @NotNull [] deserializeResponse(@NotNull String answer) throws TelegramRequestException {
+        return deserializeResponse(answer, Message[].class);
     }
 
     @Override

--- a/src/main/java/org/teleight/teleightbots/updateprocessor/BotMethodExecutor.java
+++ b/src/main/java/org/teleight/teleightbots/updateprocessor/BotMethodExecutor.java
@@ -134,6 +134,12 @@ public final class BotMethodExecutor {
                     handleInputMedia(publisher, inputMedia);
                     publisher.addPart(key, OBJECT_MAPPER.writeValueAsString(inputMedia));
                 }
+                case InputMedia[] inputMedias -> {
+                    for (InputMedia inputMedia : inputMedias) {
+                        handleInputMedia(publisher, inputMedia);
+                    }
+                    publisher.addPart(key, OBJECT_MAPPER.writeValueAsString(inputMedias));
+                }
                 case InputPaidMedia[] inputPaidMedias -> {
                     handleInputPaidMedias(publisher, inputPaidMedias);
                     publisher.addPart(key, OBJECT_MAPPER.writeValueAsString(inputPaidMedias));


### PR DESCRIPTION
had a wrong return type and didn't correctly serialize the array of input medias